### PR TITLE
Update install-modes.md

### DIFF
--- a/src/guides/node/docker.md
+++ b/src/guides/node/docker.md
@@ -378,14 +378,14 @@ Please enter the Ethstats Label (leave blank for none)
 ```
 
 This refers to a statistics aggregation service called [ethstats](https://ethstats.net/), which tracks some information about your node.
-It isn't required, and can be left blank to ignore it.
+It isn't required and can be left blank to ignore it.
 
 ```
 Please enter the Ethstats Login (leave blank for none)
 (optional - for reporting Eth 1.0 node status to ethstats.net)
 ```
 
-This lets you enter your `ethstats` credentials for data reporting, if you're using that service.
+This lets you enter your `ethstats` credentials for data reporting if you're using that service.
 Again, this is optional and can be left blank.
 
 ```
@@ -398,7 +398,7 @@ Please enter the Cache Size (leave blank for the default of 1024)
  By default, **x64** systems will use **1024 MB** and **arm64** systems will use **256 MB**.
  We have provided some guidance on general rules of thumb to set this to based on your total system RAM.
 
- **Raspberry Pi** users can safely set this to **512 MB** if planning to use **Nimbus** for the ETH2 client, otherwise it should be left at **256 MB**.
+ **Raspberry Pi** users can safely set this to **512 MB** if planning to use **Nimbus** for the ETH2 client, otherwise, it should be left at **256 MB**.
 
  ```
  Please enter the Max Peers (leave blank for the default of 50)
@@ -408,7 +408,7 @@ Please enter the Cache Size (leave blank for the default of 1024)
  ```
 
  This determines how many peers Geth will connect to.
- Generally, lower peers means lower overall data usage and lower system resource consumption.
+ Generally, lower peers mean lower overall data usage and lower system resource consumption.
  For low-power systems, this can lead to better overall validator performance.
  However, with a lower peer count, any actions you perform may take slightly longer to propagate out to the entire ETH1 network.
 
@@ -420,7 +420,7 @@ Please enter the P2P Port (leave blank for the default of 30303)
 ```
 
 This determines the TCP and UPD port that Geth will use for P2P traffic to communicate with other ETH1 nodes.
-If you have a specific setup where the default of port 30303 is not available, you can change it here.
+If you have a specific setup where the default port 30303 is not available, you can change it here.
 
 
 ### Configuring Infura
@@ -445,7 +445,7 @@ Please enter the Pocket App or Load Balancer ID (leave blank for the standard Ro
 (the ID of your Pocket App; if you use a Load Balancer, prefix it with lb/)
 ```
 
-Pocket has generously allowed Rocket Pool node operators use their network for free.
+Pocket has generously allowed Rocket Pool node operators to use their network for free.
 If you leave this blank, you can connect to the Pocket network using Rocket Pool's default project ID.
 If you have your own account with Pocket and would like to use that instead, you can enter it here.
 
@@ -503,5 +503,5 @@ It is safe to leave this at the default setting of 9001 unless your system alrea
 
 At this point, your configuration is complete.
 Congratulations!
-You're ready to start your Smartnode, and explore the CLI in greater detail.
+You're ready to start your Smartnode and explore the CLI in greater detail.
 Jump over to the [A Tour of the CLI](./cli-tutorial) section for a walkthrough of its functions, and how you can expect to use it.

--- a/src/guides/node/install-modes.md
+++ b/src/guides/node/install-modes.md
@@ -29,7 +29,7 @@ It uses the following Docker containers:
 
 In most situations, this is a good option to choose when creating a new node from scratch.
 It's the fastest, most hands-off procedure. 
-It will also handle updates to the ETH1 and ETH2 clients with every new Smartnode release, so you don't have to worry about them (though you can manually upgrade them at any time, if you desire).
+It will also handle updates to the ETH1 and ETH2 clients with every new Smartnode release, so you don't have to worry about them (though you can manually upgrade them at any time if you desire).
 
 If you would like to use this mode, proceed to the [Configuring a Standard Rocket Pool Node with Docker](./docker) section.
 
@@ -38,7 +38,7 @@ If you would like to use this mode, proceed to the [Configuring a Standard Rocke
 
 The hybrid configuration is well-suited for users that are interested in running a Rocket Pool node, but already have their own ETH1 and/or ETH2 clients running for other purposes (for example, because they're already solo-staking).
 
-In this mode, Rocket Pool will deploy Docker containers for its own processes and for an ETH2 validator, but will ignore the ETH1 and ETH2 client containers for whichever external clients you already run and maintain.
+In this mode, Rocket Pool will deploy Docker containers for its own processes and for an ETH2 validator but will ignore the ETH1 and ETH2 client containers for whichever external clients you already run and maintain.
 As Rocket Pool will be creating and maintaining new validator keys for each of your node's minipools, it is important that it runs its own ETH2 validator client.
 
 When using this configuration, the Smartnode will use the following Docker containers (which were described above):
@@ -62,8 +62,8 @@ This configuration bypasses Docker entirely.
 Instead of running the Smartnode stack via Docker, each process will be installed as a local system service (e.g. via `systemd`).
 This includes the `node`, `watchtower`, `eth1`, `eth2`, and `validator` processes.
 
-This configuration offers the most flexibility, because it allows you to fine-tune Rocket Pool's parameters (such as its security posture, where the ETH1 and ETH2 clients live, where the chain data lives, where your keys live, and so on).
-It is also the most difficult to setup and maintain.
+This configuration offers the most flexibility because it allows you to fine-tune Rocket Pool's parameters (such as its security posture, where the ETH1 and ETH2 clients live, where the chain data lives, where your keys live, and so on).
+It is also the most difficult to set up and maintain.
 
 In this mode, the Smartnode Installer is no longer relevant.
 You are responsible for manually instantiating, maintaining, and upgrading the Smartnode infrastructure, the ETH clients, and the validator clients.


### PR DESCRIPTION
Removed a few commas, and changed setup to 'set up'.

Setup is one word when it is a noun (e.g., “it was a setup!”) or an adjective (e.g., “follow the setup instructions”). It is two words—set up—when it functions as a verb (e.g., “I’m going to set up the computer”).