### PR TITLE
[docs] tweak the chown eth2 path for nimbus service creation

### DIFF
--- a/src/guides/node/native.md
+++ b/src/guides/node/native.md
@@ -611,7 +611,7 @@ sudo mkdir -p /srv/rocketpool/data/validators/nimbus/validators
 
 sudo mkdir -p /srv/rocketpool/data/validators/nimbus/secrets
 
-sudo chown eth2:eth2 /srv/rocketpool/data/ -R
+sudo chown eth2:eth2 /srv/rocketpool/data/validators/ -R
 ```
 
 Next, we have to give the `rp` user the ability to restart the validator client when new validator keys are created.
@@ -752,7 +752,7 @@ sudo mkdir -p /srv/rocketpool/data/validators/nimbus/validators
 
 sudo mkdir -p /srv/rocketpool/data/validators/nimbus/secrets
 
-sudo chown eth2:eth2 /srv/rocketpool/data/ -R
+sudo chown eth2:eth2 /srv/rocketpool/data/validators/ -R
 ```
 
 Next, we have to give the `rp` user the ability to restart the validator client when new validator keys are created.


### PR DESCRIPTION
Following the instructions as-is causes problems when trying to recover a wallet, because the rocketpool/data/password and rocketpool/data/wallet files end up owned by the eth2 user. This causes the rp restore/init commands to fail since the $USER running those commands doesn't own those files (neither does rp user).

Making this chown a little more specific avoids this issue