### PR TITLE
Add Automatic Dark Mode

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11130,6 +11130,11 @@
         "smoothscroll-polyfill": "^0.4.3"
       }
     },
+    "vuepress-theme-default-prefers-color-scheme": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/vuepress-theme-default-prefers-color-scheme/-/vuepress-theme-default-prefers-color-scheme-2.0.0.tgz",
+      "integrity": "sha512-4sA3DCiaIIHVjcIC5+mF00mf29IU27KSH97Ga4xb4nUwwlC6eYHg2qchEVOgV25XogCtGgpZ/DCrTkywxvuBcg=="
+    },
     "watchpack": {
       "version": "1.7.5",
       "resolved": "https://registry.npmjs.org/watchpack/-/watchpack-1.7.5.tgz",

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "vuepress-plugin-element-tabs": "^0.2.8"
   },
   "dependencies": {
-    "vuepress-plugin-code-copy": "^1.0.6"
+    "vuepress-plugin-code-copy": "^1.0.6",
+    "vuepress-theme-default-prefers-color-scheme": "^2.0.0"
   }
 }

--- a/src/.vuepress/config.js
+++ b/src/.vuepress/config.js
@@ -22,6 +22,11 @@ module.exports = {
   ],
 
   /**
+   * ref：https://v1.vuepress.vuejs.org/config/#theme
+   */
+  theme: 'default-prefers-color-scheme',
+
+  /**
    * Theme configuration, here is the default theme configuration for VuePress.
    *
    * ref：https://v1.vuepress.vuejs.org/theme/default-theme-config.html

--- a/src/.vuepress/styles/palette.styl
+++ b/src/.vuepress/styles/palette.styl
@@ -5,6 +5,7 @@
  */
 
 $accentColor = #ea894d
+$accentDarkColor = #ea894d
 $textColor = #2c3e50
 $borderColor = #eaecef
 $codeBgColor = #282c34


### PR DESCRIPTION
Automatically enables Dark Mode if the device prefers a dark color scheme.
Theme Source: https://tolking.github.io/vuepress-theme-default-prefers-color-scheme
<img src="https://i.imgur.com/6Rh31Ky.png" width="50%"><img src="https://i.imgur.com/Ys3XUtE.png" width="50%">