### PR TITLE
Add Automatic Dark Mode [Fixed]

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11130,6 +11130,11 @@
         "smoothscroll-polyfill": "^0.4.3"
       }
     },
+    "vuepress-theme-default-prefers-color-scheme": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/vuepress-theme-default-prefers-color-scheme/-/vuepress-theme-default-prefers-color-scheme-2.0.0.tgz",
+      "integrity": "sha512-4sA3DCiaIIHVjcIC5+mF00mf29IU27KSH97Ga4xb4nUwwlC6eYHg2qchEVOgV25XogCtGgpZ/DCrTkywxvuBcg=="
+    },
     "watchpack": {
       "version": "1.7.5",
       "resolved": "https://registry.npmjs.org/watchpack/-/watchpack-1.7.5.tgz",

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "vuepress-plugin-element-tabs": "^0.2.8"
   },
   "dependencies": {
-    "vuepress-plugin-code-copy": "^1.0.6"
+    "vuepress-plugin-code-copy": "^1.0.6",
+    "vuepress-theme-default-prefers-color-scheme": "^2.0.0"
   }
 }

--- a/src/.vuepress/config.js
+++ b/src/.vuepress/config.js
@@ -22,6 +22,11 @@ module.exports = {
   ],
 
   /**
+   * ref：https://v1.vuepress.vuejs.org/config/#theme
+   */
+  theme: 'default-prefers-color-scheme',
+
+  /**
    * Theme configuration, here is the default theme configuration for VuePress.
    *
    * ref：https://v1.vuepress.vuejs.org/theme/default-theme-config.html

--- a/src/.vuepress/styles/index.styl
+++ b/src/.vuepress/styles/index.styl
@@ -32,4 +32,39 @@ div[class*="language-"]
   color: #000;
   background-color: rgba(27,31,35,0.075)
 
+/** 
+ * Darkmode color-fixes
+ */
 
+@media (prefers-color-scheme: dark)
+  :root
+    --codeBgColor: #282c34;
+    --preTextColor: #fff;
+    --highlightedBgColor: rgba(0,0,0,0.66);
+    --languageTextColor: rgba(255,255,255,0.4);
+    --lineNumbersColor: rgba(255,255,255,0.3);
+
+@media (prefers-color-scheme: dark)
+  h3
+    background-color: #563329;
+
+@media (prefers-color-scheme: dark)
+  .theme-default-content code
+    color: #fff !important;
+    background-color: #333 !important;
+
+@media (prefers-color-scheme: dark)
+  .el-tabs--border-card
+    background-color: #18191b !important;
+    border: 1px solid #191d24 !important;
+
+@media (prefers-color-scheme: dark)
+  .el-tabs__header
+    background-color: #18191b !important;
+    border: 1px solid #25272a !important;
+
+@media (prefers-color-scheme: dark)
+  .el-tabs__item.is-active
+    background-color: #18191b !important;
+    border-right-color: #25272a !important;
+    border-left-color: #25272a !important;

--- a/src/.vuepress/styles/palette.styl
+++ b/src/.vuepress/styles/palette.styl
@@ -5,6 +5,7 @@
  */
 
 $accentColor = #ea894d
+$accentDarkColor = #ea894d
 $textColor = #2c3e50
 $borderColor = #eaecef
 $codeBgColor = #282c34


### PR DESCRIPTION
Automatically enables Dark Mode if the device prefers a dark color scheme.
Theme Source: https://tolking.github.io/vuepress-theme-default-prefers-color-scheme
<img src="https://i.imgur.com/6Rh31Ky.png" width="50%"><img src="https://i.imgur.com/Ys3XUtE.png" width="50%">

# Fixes:
| Before  | After |
| -------- | ----- |
|<img src="https://cdn.discordapp.com/attachments/487119657451651073/888464565355044864/unknown.png">|<img src="https://url.invis.cloud/sNU5s1">|
|<img src="https://cdn.discordapp.com/attachments/487119657451651073/888464832892911626/unknown.png">|<img src="https://url.invis.cloud/gwufUD">|