### PR TITLE
Fix ETH1 endpoint in Teku systemd config

### DIFF
--- a/src/guides/node/native.md
+++ b/src/guides/node/native.md
@@ -748,7 +748,7 @@ Type=simple
 User=eth2
 Restart=always
 RestartSec=5
-ExecStart=/srv/teku/bin/teku --network=mainnet --data-path=/srv/teku/teku_data --p2p-port=9001 --eth1-endpoint=9001 --rest-api-enabled --rest-api-port=5052 -eth1-deposit-contract-max-request-size=150
+ExecStart=/srv/teku/bin/teku --network=mainnet --data-path=/srv/teku/teku_data --p2p-port=9001 --eth1-endpoint=http://localhost:8545 --rest-api-enabled --rest-api-port=5052 -eth1-deposit-contract-max-request-size=150
 
 [Install]
 WantedBy=multi-user.target
@@ -921,7 +921,7 @@ Type=simple
 User=eth2
 Restart=always
 RestartSec=5
-ExecStart=ionice -c 2 -n 0 /srv/teku/bin/teku --network=mainnet --data-path=/mnt/rpdata/teku_data --p2p-port=9001 --eth1-endpoint=9001 --rest-api-enabled --rest-api-port=5052 -eth1-deposit-contract-max-request-size=150
+ExecStart=ionice -c 2 -n 0 /srv/teku/bin/teku --network=mainnet --data-path=/mnt/rpdata/teku_data --p2p-port=9001 --eth1-endpoint=http://localhost:8545 --rest-api-enabled --rest-api-port=5052 -eth1-deposit-contract-max-request-size=150
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
Your systemd service definitions for Teku incorrectly list the GETH endpoint as port 9001. This results in Teku looking at the port it is itself listening on, and being unable to connect to GETH.