### PR TITLE
Allow native install of Teku Validator to start

### DIFF
--- a/src/guides/node/native.md
+++ b/src/guides/node/native.md
@@ -577,6 +577,8 @@ sudo chown eth2:eth2 /srv/prysm/genesis.ssz
 sudo mkdir /srv/teku
 
 sudo chown $USER:$USER /srv/teku
+
+sudo mkhomedir_helper rp
 ```
 
 Next, make a folder for Teku's chain data on the SSD.


### PR DESCRIPTION
The Teku Validator client by default wants to log to `/home/rp/.local/share/teku/logs`, so the `rp` user's home directory must exist or it will fail to start. I offer this merely as a suggestion and to bring awareness to the problem, I'm not tied to any particular solution. A better fix may be to configure Teku Validator to log somewhere else.

https://docs.teku.consensys.net/en/latest/HowTo/Monitor/Logging/