### PR TITLE
Clarify a contradiction in the docs for those following the native config

### DIFF
--- a/src/guides/node/starting-rp.md
+++ b/src/guides/node/starting-rp.md
@@ -169,7 +169,7 @@ Selected Eth 2.0 client: Nimbus (statusim/nimbus-eth2:multiarch-v1.4.2)
 The first line will tell you if your Smartnode is configured for the Ethereum mainnet or for the Prater testnet.
 
 ::: warning NOTE
-If you are not on the network you expect to be on, go back to the Installing Rocket Pool section and review the installation instructions - you may have missed the portion that has different instructions depending on which network you want to use.
+If you are not on the network you expect to be on, go back to the Installing Rocket Pool section and review the installation instructions - you may have missed the portion that has different instructions depending on which network you want to use. BUT If you are on the native config and you accepted default parameters when you ran ```rp service config```, then it's likely these don't match and that's ok because your systemctl scripts should contain the correct config
 :::
 
 The second set of lines will tell you which clients you're using, and which versions of them are defined in Rocket Pool's `config.yml` file.

--- a/src/guides/node/starting-rp.md
+++ b/src/guides/node/starting-rp.md
@@ -169,7 +169,12 @@ Selected Eth 2.0 client: Nimbus (statusim/nimbus-eth2:multiarch-v1.4.2)
 The first line will tell you if your Smartnode is configured for the Ethereum mainnet or for the Prater testnet.
 
 ::: warning NOTE
-If you are not on the network you expect to be on, go back to the Installing Rocket Pool section and review the installation instructions - you may have missed the portion that has different instructions depending on which network you want to use. BUT If you are on the native config and you accepted default parameters when you ran ```rp service config```, then it's likely these don't match and that's ok because your systemctl scripts should contain the correct config
+**For Docker / Hybrid users:**
+If you are not on the network you expect to be on, go back to the Installing Rocket Pool section and review the installation instructions - you may have missed the portion that has different instructions depending on which network you want to use.
+
+**For Native users:**
+If you accepted the default settings when you first ran `rp service config`, then it's possible that the network reported here is incorrect.
+However, your `systemctl` service definitions *should* have the correct network baked directly into the command line arguments so you can ignore this discrepancy unless it bothers you. 
 :::
 
 The second set of lines will tell you which clients you're using, and which versions of them are defined in Rocket Pool's `config.yml` file.


### PR DESCRIPTION
The [native config docs](https://docs.rocketpool.net/guides/node/native.html#setting-up-the-binaries) on setting up the binaries tell you to run "rp service config" and skip through while accepting default parameters (which is ok)

But a [later section](https://docs.rocketpool.net/guides/node/starting-rp.html#confirming-the-correct-version-and-network) tells you to run "rocketpool service config" to make sure that the network parameters make sense and if not go back to the previous section. This should seem pretty obvious for most users, but it might cause some circular/confusing setup experience

Note: Tried to run ```npm run dev``` to verify the changes, but it wouldn't load for me in brave browser. main branch wouldn' run for me locally either. but i assume that's ok, given the doc-only nature of this changeset