### PR TITLE
Modify command line example so that it shows 0 effective RPL staked before ETH is staked. 

### DIFF
--- a/src/guides/node/create-validator.md
+++ b/src/guides/node/create-validator.md
@@ -53,8 +53,8 @@ Once both transactions finish, you can check your staked RPL amount with `rocket
 The following portion of the output is what you want to verify:
 
 ```
-The node has a total stake of 11763.477483 RPL and an effective stake of 11763.477483 RPL, allowing it to run 41 minipool(s) in total.
-This is currently a 10.88% collateral ratio.
+The node has a total stake of 11763.477483 RPL and an effective stake of 0.0 RPL, allowing it to run 41 minipool(s) in total.
+This is currently a 0.00% collateral ratio.
 The node must keep at least 10810.143971 RPL staked to collateralize its minipools and claim RPL rewards.
 ```
 

--- a/src/guides/node/ssh.md
+++ b/src/guides/node/ssh.md
@@ -70,8 +70,15 @@ You will be greeted with a welcome message, some details about your machine, and
 
 At this point, everything you type in the terminal **is executed remotely on your node machine** - it's as if you were logged directly into the node machine and typing on it with a locally-attached keyboard!
 
-You'll need to be able to ssh into the terminal periodically for updates and maintenance. It can be inconvenient to remember how to log in to your node, so it may be helpful to shorten this command by creating a memorable alias. If you do this, be sure to create the alias on the client machine, not while logged into the node. So if your terminal is still connected to the node, first run `exit` at the command prompt, or open a new terminal window locally.
+You'll need to SSH into the terminal periodically for updates and maintenance.
+It can be inconvenient to remember how to log in to your node, so it may be helpful to shorten this command by creating a memorable alias - a custom "shortcut" command.
 
+::: warning NOTE
+If you do this, be sure to create the alias on the **client machine**, **not** on the node!
+If your terminal is still connected to the node, first run `exit` at the command prompt (or simply open a new terminal window).
+:::
+
+In this example, we'll create an alias called `ethnode` which will replace the SSH command.
 Assuming, as before, that your node's username is `staker` and your node's IP address is `192.168.1.10`, create the alias with the following command:
 
 ```sh
@@ -83,7 +90,7 @@ Reload the alias list to make your current terminal window aware of the new alia
 source ~/.bash_aliases
 ```
 
-And now connect to the node using the alias you just created:
+Now, you can connect to the node using the alias you just created instead of the longer command that involves specifying the node's IP address:
 
 ```sh
 ethnode

--- a/src/guides/node/ssh.md
+++ b/src/guides/node/ssh.md
@@ -69,3 +69,22 @@ The client will then prompt you for your user's password; once you enter that, y
 You will be greeted with a welcome message, some details about your machine, and a new prompt.
 
 At this point, everything you type in the terminal **is executed remotely on your node machine** - it's as if you were logged directly into the node machine and typing on it with a locally-attached keyboard!
+
+You'll need to be able to ssh into the terminal periodically for updates and maintenance. It can be inconvenient to remember how to log in to your node, so it may be helpful to shorten this command by creating a memorable alias. If you do this, be sure to create the alias on the client machine, not while logged into the node. So if your terminal is still connected to the node, first run `exit` at the command prompt, or open a new terminal window locally.
+
+Assuming, as before, that your node's username is `staker` and your node's IP address is `192.168.1.10`, create the alias with the following command:
+
+```sh
+echo "alias ethnode='ssh staker@192.168.1.10'" >> ~/.bash_aliases
+```
+
+Reload the alias list to make your current terminal window aware of the new alias:
+```sh
+source ~/.bash_aliases
+```
+
+And now connect to the node using the alias you just created:
+
+```sh
+ethnode
+```


### PR DESCRIPTION
I edited the command line output so that it says that the effective state is 0 RPL. (At this point in the guide the NO has not yet staked any RPL to have an effective stake. This was based on the feedback here https://discord.com/channels/405159462932971535/774497904559783947/905866822367191110