### PR TITLE
Refactor rETH Overview - rETH/ETH Exchange Rate and rETH Post Merge

### DIFF
--- a/src/guides/staking/overview.md
+++ b/src/guides/staking/overview.md
@@ -91,6 +91,7 @@ In this scenario, you may find other ways to trade your rETH back to ETH (such a
 As an alternative to holding onto and eventually returning your rETH to the Rocket Pool, you are also free to **use it in DeFi applications**.
 You can trade it, lend it, use it as collateral... as rETH is a standard ERC20 token, you can use it in any way you could use any other token.
 
+After the Ethereum proof-of-stake (PoS) merge and enabling of staked ETH withdraws, rETH will remain a separate ERC-20 token from ETH.
 
 ## Tax Implications
 

--- a/src/guides/staking/overview.md
+++ b/src/guides/staking/overview.md
@@ -51,7 +51,7 @@ The value of rETH is determined by the following ratio:
 rETH:ETH ratio =  (total ETH staked + Beacon Chain rewards) / (total ETH staked)
 ```
 
-Since the Beacon Chain rewards will always be positive and will constantly grow, this means that **rETH's value effectively always increases relative to ETH**.
+Since the Beacon Chain rewards will always be positive and will constantly grow, this means that **rETH's value effectively always increases relative to ETH**. The rETH/ETH exchange rate is updated every 24 hours based on Rocket Pool network's rewards earned.
 
 To illustrate this point, here is a chart of rETH's value (relative to ETH) over time - as expected, it demonstrates slow but steady growth:
 

--- a/src/guides/staking/overview.md
+++ b/src/guides/staking/overview.md
@@ -51,7 +51,8 @@ The value of rETH is determined by the following ratio:
 rETH:ETH ratio =  (total ETH staked + Beacon Chain rewards) / (total ETH staked)
 ```
 
-Since the Beacon Chain rewards will always be positive and will constantly grow, this means that **rETH's value effectively always increases relative to ETH**. The rETH/ETH exchange rate is updated every 24 hours based on Rocket Pool network's rewards earned.
+Since the Beacon Chain rewards will always be positive and will constantly grow, this means that **rETH's value effectively always increases relative to ETH**.
+The rETH/ETH exchange rate is updated approximately every 24 hours based on the Beacon Chain rewards earned by Rocket Pool node operators.
 
 To illustrate this point, here is a chart of rETH's value (relative to ETH) over time - as expected, it demonstrates slow but steady growth:
 
@@ -91,7 +92,10 @@ In this scenario, you may find other ways to trade your rETH back to ETH (such a
 As an alternative to holding onto and eventually returning your rETH to the Rocket Pool, you are also free to **use it in DeFi applications**.
 You can trade it, lend it, use it as collateral... as rETH is a standard ERC20 token, you can use it in any way you could use any other token.
 
-After the Ethereum proof-of-stake (PoS) merge and enabling of staked ETH withdraws, rETH will remain a separate ERC-20 token from ETH.
+::: tip NOTE
+After the Ethereum Proof-of-Stake (PoS) merge and enabling of staked ETH withdrawals, **rETH will still remain a separate ERC-20 token from ETH**.
+:::
+
 
 ## Tax Implications
 


### PR DESCRIPTION
There are other ETH staking tokens, such as Coinbase's ETH2, that will be merged back into ETH after the merge. Therefore, this is a useful distinction for users to understand how various staked ETH options compare after the PoS merge.