### PR TITLE
Clarify instructions for Grafana SMTP settings

### DIFF
--- a/src/guides/node/grafana.md
+++ b/src/guides/node/grafana.md
@@ -487,9 +487,12 @@ GF_<SectionName>_<KeyName>
 
 ### Grafana SMTP Settings for Sending Emails
 
-To send emails from Grafana, e.g. for alerts or to invite other users, SMTP settings need to be configured in the Rocket Pool Metrics Stack. See the [Grafana SMTP configuration](https://grafana.com/docs/grafana/latest/administration/configuration/#smtp) page for reference.
+To send emails from Grafana, e.g. for alerts or to invite other users, SMTP settings need to be configured in the Rocket Pool Metrics Stack.
+See the [Grafana SMTP configuration](https://grafana.com/docs/grafana/latest/administration/configuration/#smtp) page for reference.
 
-Open `~/.rocketpool/docker-compose-metrics.yml` in a text editor. Include the below `GF_SMTP_<KEYNAME>` environment variables in the `environment` section of the `grafana` service, replacing the values with those for your SMTP provider. If using Gmail and [2-Step Verification](https://support.google.com/accounts/answer/185839) is enabled, create an [App Password](https://support.google.com/mail/answer/185833?hl=en) for this service.
+Open `~/.rocketpool/docker-compose-metrics.yml` in a text editor.
+Include the below `GF_SMTP_<KEYNAME>` environment variables in the `environment` section of the `grafana` service, replacing the values with those for your SMTP provider.
+If using Gmail and [2-Step Verification](https://support.google.com/accounts/answer/185839) is enabled, create an [App Password](https://support.google.com/mail/answer/185833?hl=en) for this service.
 
 ```yaml
 version: "3.4"

--- a/src/guides/node/grafana.md
+++ b/src/guides/node/grafana.md
@@ -522,6 +522,14 @@ services:
 ...
 ```
 
+After making these modifications, **run the following to apply the changes**:
+
+```
+docker stop rocketpool_grafana
+
+rocketpool service start
+```
+
 To test the SMTP settings, go to the **Alerting** menu and click **Notification channels**.
 
 <center>

--- a/src/guides/node/grafana.md
+++ b/src/guides/node/grafana.md
@@ -489,21 +489,21 @@ GF_<SectionName>_<KeyName>
 
 To send emails from Grafana, e.g. for alerts or to invite other users, SMTP settings need to be configured in the Rocket Pool Metrics Stack. See the [Grafana SMTP configuration](https://grafana.com/docs/grafana/latest/administration/configuration/#smtp) page for reference.
 
-Open `~/.rocketpool/docker-compose-metrics.yml` in a text editor. Include the below `GF_SMTP_<KEYNAME>` environment variables in the `environment` section of the `grafana` service:
+Open `~/.rocketpool/docker-compose-metrics.yml` in a text editor. Include the below `GF_SMTP_<KEYNAME>` environment variables in the `environment` section of the `grafana` service, replacing the values with those for your SMTP provider. If using Gmail and [2-Step Verification](https://support.google.com/accounts/answer/185839) is enabled, create an [App Password](https://support.google.com/mail/answer/185833?hl=en) for this service.
 
 ```yaml
 version: "3.4"
 services:
 ...
   grafana:
-    image: grafana/grafana:8.1.1
+    image: grafana/grafana:8.3.2
     container_name: ${COMPOSE_PROJECT_NAME}_grafana
     restart: unless-stopped
     environment:
       - GF_SERVER_HTTP_PORT=${GRAFANA_PORT:-3100}
-      ## SMTP settings start
+      ## SMTP settings start, replace values with those of your SMTP provider
       - GF_SMTP_ENABLED=true
-      - GF_SMTP_HOST=mail.example.com:<port>
+      - GF_SMTP_HOST=mail.example.com:<port>  # Gmail users should use smtp.gmail.com:587
       - GF_SMTP_USER=admin@example.com
       - GF_SMTP_PASSWORD=password
       - GF_SMTP_FROM_ADDRESS=admin@example.com


### PR DESCRIPTION
Original instructions were unclear that SMTP settings needed to be replaced with user's own SMTP provider details. This PR includes additional details to clarify that. It also includes some basic tips for using Gmail, which is a common SMTP provider for self-hosted services like Grafana.