### PR TITLE
group write permission for rp data folder

### DIFF
--- a/src/guides/node/native.md
+++ b/src/guides/node/native.md
@@ -1260,6 +1260,8 @@ Once that's done, change the permissions on the password and wallet files so the
 ```
 sudo chown rp:rp -R /srv/rocketpool/data
 
+sudo chmod -R 775 /srv/rocketpool/data
+
 sudo chmod 660 /srv/rocketpool/data/password
 
 sudo chmod 660 /srv/rocketpool/data/wallet


### PR DESCRIPTION
need for group to be able to write new folders when performing rp node deposit

was getting the following error when performing `rp node deposit`

```
Could not make node deposit: Could not store lighthouse validator key: Could not write validator secret to disk: open /srv/rocketpool/data/validators/lighthouse/secrets/0xb8678ba87f86573a727b6e7f49e4133b32c2bc9311bd3d2f81d0a43e6c101c85f0f4d489094c1a34818d10b7b8c97e2e: permission denied
```

adding the write permission would fix this. does it make sense to add this instead to the deposit step and include reverting after?