### PR TITLE
Fixed a few links to checkpoint syncing section

### DIFF
--- a/src/guides/node/config-docker.md
+++ b/src/guides/node/config-docker.md
@@ -712,7 +712,7 @@ If you'd like to see some examples of what validators are using for Graffiti tod
 :::::::
 
 
-### Beacon Chain Checkpoint Syncing with Infura
+#### Beacon Chain Checkpoint Syncing with Infura
 
 **Checkpoint syncing** is a very useful technique that some Beacon Chain clients support.
 It allows your Beacon client to instantly sync the entire Beacon chain without having to start from the beginning and catch up on every block.

--- a/src/guides/node/config-docker.md
+++ b/src/guides/node/config-docker.md
@@ -361,7 +361,7 @@ Take a look at [their documentation on checkpoint syncing](https://lighthouse-bo
 You can enter the URL of any Beacon Node that provides access to its REST API here.
 One popular option is Infura, which offers this service for free (though it requires you to create an account).
 
-See [the section below on Checkpoint Syncing](#eth2-checkpoint-syncing-with-infura) if you'd like to use it.
+See [the section below on Checkpoint Syncing](#beacon-chain-checkpoint-syncing-with-infura) if you'd like to use it.
 
 The final question will ask if you want to enable Doppelgänger Protection:
 
@@ -419,7 +419,7 @@ Take a look at [their documentation on checkpoint syncing](https://nimbus.guide/
 You can enter the URL of any Beacon Node that provides access to its REST API here.
 One popular option is Infura, which offers this service for free (though it requires you to create an account).
 
-See [the section below on Checkpoint Syncing](#eth2-checkpoint-syncing-with-infura) if you'd like to use it.
+See [the section below on Checkpoint Syncing](#beacon-chain-checkpoint-syncing-with-infura) if you'd like to use it.
 
 The final question will ask if you want to enable Doppelgänger Protection:
 
@@ -518,7 +518,7 @@ Take a look at [their documentation on checkpoint syncing](https://docs.teku.con
 You can enter the URL of any Beacon Node that provides access to its REST API here.
 One popular option is Infura, which offers this service for free (though it requires you to create an account).
 
-See [the section below on Checkpoint Syncing](#eth2-checkpoint-syncing-with-infura) if you'd like to use it.
+See [the section below on Checkpoint Syncing](#beacon-chain-checkpoint-syncing-with-infura) if you'd like to use it.
 
 :::
 ::::
@@ -712,7 +712,7 @@ If you'd like to see some examples of what validators are using for Graffiti tod
 :::::::
 
 
-#### Beacon Chain Checkpoint Syncing with Infura
+### Beacon Chain Checkpoint Syncing with Infura
 
 **Checkpoint syncing** is a very useful technique that some Beacon Chain clients support.
 It allows your Beacon client to instantly sync the entire Beacon chain without having to start from the beginning and catch up on every block.


### PR DESCRIPTION
links to the '''###Beacon Chain Checkpoint Syncing with Infura''' broken as the md pointer was pointing to '''eth2-checkpoint-syncing-with-infura''' which I assume was updated to show Beacon chain when eth2 term was deprecated.
the title pointed to itself also had an extra #, which caused it to not render in a lg pink box as the entire section. made for inconsistency with the format of the rest of the page