### PR TITLE
Update swap docs to be a bit more clear

### DIFF
--- a/src/guides/node/local/prepare-pc.md
+++ b/src/guides/node/local/prepare-pc.md
@@ -217,8 +217,6 @@ $ sudo nano /etc/fstab
 
 Add a new line at the end that looks like this:
 ```
-LABEL=writable  /        ext4   defaults        0 0
-...
 /swapfile                            none            swap    sw              0       0
 ```
 

--- a/src/guides/node/local/prepare-pi.md
+++ b/src/guides/node/local/prepare-pi.md
@@ -334,7 +334,7 @@ Finally, add it to the mount table so it automatically loads when your Pi reboot
 $ sudo nano /etc/fstab
 ```
 
-Add a new line at the end that looks like this:
+Add a new line at the end so that the file looks like this:
 ```
 LABEL=writable  /        ext4   defaults        0 0
 LABEL=system-boot       /boot/firmware  vfat    defaults        0       1

--- a/src/guides/node/vps/os.md
+++ b/src/guides/node/vps/os.md
@@ -192,8 +192,6 @@ $ sudo nano /etc/fstab
 
 Add a new line at the end that looks like this:
 ```
-LABEL=writable  /        ext4   defaults        0 0
-...
 /swapfile                            none            swap    sw              0       0
 ```
 


### PR DESCRIPTION
I think the confusion introduced by having /etc/fstab context outweighs the benefit it provides, modulo raspberry pi setup, which involves _more_ fstab hacking