### PR TITLE
Fix inconsistency with install guide

### DIFF
--- a/src/guides/node/updates.md
+++ b/src/guides/node/updates.md
@@ -256,7 +256,7 @@ wget https://github.com/rocket-pool/smartnode-install/releases/latest/download/r
 
 For `arm64` systems, such as the Mac mini with M1:
 ```shell
-wget https://github.com/rocket-pool/smartnode-install/releases/latest/download/rocketpool-cli-darwin-arm64 -O /usr/local/bin/rocketpool
+wget https://github.com/rocket-pool/smartnode-install/releases/latest/download/rocketpool-cli-darwin-arm64 -O /opt/homebrew/bin/rocketpool
 ```
 
 Now run the install command:


### PR DESCRIPTION
In the Installing Rocket Pool section, we recommend M1 users to install to `/opt/homebrew/bin/rocketpool` so they should apply their updates to the same path.