### PR TITLE
Update deposit contract address

### DIFF
--- a/src/overview/contracts-integrations.md
+++ b/src/overview/contracts-integrations.md
@@ -13,9 +13,9 @@ If you would like to contribute by helping integrate Rocket Pool into more servi
 
 Chain    | Contract | Address
 ---------|----------|---------
-Mainnet  | Deposit  | [0x4D05E3d48a938db4b7a9A59A802D5b45011BDe58](https://etherscan.io/address/0x4D05E3d48a938db4b7a9A59A802D5b45011BDe58)
+Mainnet  | Deposit  | [0x2cac916b2A963Bf162f076C0a8a4a8200BCFBfb4](https://etherscan.io/address/0x2cac916b2A963Bf162f076C0a8a4a8200BCFBfb4)
 &nbsp;   | Storage  | [0x1d8f8f00cfa6758d7bE78336684788Fb0ee0Fa46](https://etherscan.io/address/0x1d8f8f00cfa6758d7bE78336684788Fb0ee0Fa46)
-Goerli*  | Deposit  | [0x923Ed282Cda8952910B71B5efcA7CDa09e39c633](https://goerli.etherscan.io/address/0x923Ed282Cda8952910B71B5efcA7CDa09e39c633)
+Goerli*  | Deposit  | [0x2cac916b2A963Bf162f076C0a8a4a8200BCFBfb4](https://goerli.etherscan.io/address/0x2cac916b2A963Bf162f076C0a8a4a8200BCFBfb4)
 &nbsp;   | Storage  | [0xd8Cd47263414aFEca62d6e2a3917d6600abDceB3](https://goerli.etherscan.io/address/0xd8Cd47263414aFEca62d6e2a3917d6600abDceB3)
 
 <small>* Testnet</small>
@@ -35,6 +35,17 @@ Polygon  | RPL   | [0x7205705771547cf79201111b4bd8aaf29467b9ec](https://polygons
 &nbsp;   | rETH  | [0x0266F4F08D82372CF0FcbCCc0Ff74309089c74d1](https://polygonscan.com/token/0x0266F4F08D82372CF0FcbCCc0Ff74309089c74d1)
 Goerli*  | RPL   | [0x5e932688e81a182e3de211db6544f98b8e4f89c7](https://goerli.etherscan.io/address/0x5e932688e81a182e3de211db6544f98b8e4f89c7)
 &nbsp;   | rETH  | [0x178E141a0E3b34152f73Ff610437A7bf9B83267A](https://goerli.etherscan.io/address/0x178E141a0E3b34152f73Ff610437A7bf9B83267A)
+
+<small>* Testnet</small>
+
+## Deposit Pool Contract Version History
+
+Chain    | Version        | Address
+---------|----------------|---------
+Mainnet  | v1.1 (current) | [0x2cac916b2A963Bf162f076C0a8a4a8200BCFBfb4](https://etherscan.io/address/0x2cac916b2A963Bf162f076C0a8a4a8200BCFBfb4)
+&nbsp;   | v1.0           | [0x4D05E3d48a938db4b7a9A59A802D5b45011BDe58](https://etherscan.io/address/0x4D05E3d48a938db4b7a9A59A802D5b45011BDe58)
+Goerli*  | v1.1 (current) | [0x2cac916b2A963Bf162f076C0a8a4a8200BCFBfb4](https://goerli.etherscan.io/address/0x2cac916b2A963Bf162f076C0a8a4a8200BCFBfb4)
+&nbsp;   | v1.0           | [0x923Ed282Cda8952910B71B5efcA7CDa09e39c633](https://goerli.etherscan.io/address/0x923Ed282Cda8952910B71B5efcA7CDa09e39c633)
 
 <small>* Testnet</small>
 


### PR DESCRIPTION
After the redstone update, the deposit contract address changed and needs updating. I added a version history for the deposit contract - I assume that would be useful for any developer who has interacted with the v1.0 contract.

Open questions:
* Should we add a quick blurb on best practices for accessing the current deposit contract? Will defer to others to address.