### PR TITLE
Replace old mentions of CLI binary with new one

### DIFF
--- a/src/guides/node/config-native.md
+++ b/src/guides/node/config-native.md
@@ -26,7 +26,7 @@ Choose which mode you'd like to learn more about from the list above, or simply 
 To configure the Smartnode, run the configuration command:
 
 ```
-rp service config
+rocketpool service config
 ```
 
 This will launch a terminal-based UI that will allow you to quickly and easily configure your node, as well as provide optional fine-grained control over the settings that are relevant to Native mode.

--- a/src/guides/node/starting-rp.md
+++ b/src/guides/node/starting-rp.md
@@ -178,8 +178,8 @@ The first line will tell you if your Smartnode is configured for the Ethereum ma
 If you are not on the network you expect to be on, go back to the Installing Rocket Pool section and review the installation instructions - you may have missed the portion that has different instructions depending on which network you want to use.
 
 **For Native users:**
-If you accepted the default settings when you first ran `rp service config`, then it's possible that the network reported here is incorrect.
-Simply switch it in the `rp service config` TUI, in the `Smartnode` section, to the proper network and restart your `node` and `watchtower` services.
+If you accepted the default settings when you first ran `rocketpool service config`, then it's possible that the network reported here is incorrect.
+Simply switch it in the `rocketpool service config` TUI, in the `Smartnode` section, to the proper network and restart your `node` and `watchtower` services.
 :::
 
 The second set of lines will tell you which clients you're using, and which versions of them are defined in Rocket Pool's configuration.

--- a/src/guides/node/updates.md
+++ b/src/guides/node/updates.md
@@ -221,7 +221,7 @@ sudo chmod +x /usr/local/bin/rocketpool /usr/local/bin/rocketpoold
 If you'd like to see what's changed, open the Settings Manager - the Review Page will show you what's new:
 
 ```
-rp service config
+rocketpool service config
 ```
 
 When you're done, start Rocket Pool up again:


### PR DESCRIPTION
In the docs we have a few lingering `rp` mentions instead of `rocketpool` for the binary. 