### PR TITLE
tell minipool operators about rocketarb

### DIFF
--- a/src/guides/node/create-validator.md
+++ b/src/guides/node/create-validator.md
@@ -202,7 +202,9 @@ The value of the arbitrage is equal to the amount of protocol ETH in the minipoo
 E.g., if making a minipool when there's a 2.5% premium: `16 ETH * .025 = 0.4 ETH`.
 In other words, you could receive 0.4 ETH back during these conditions just for creating a minipool!
 
-If you're interested in taking advantage of this opportunity, feel free to inquire about it on the [RP discord server](https://discord.gg/rocketpool).
+If you're interested in taking advantage of this opportunity, consider using the community-developed [rocketarb](https://github.com/xrchz/rocketarb/blob/main/README.md) tool to capture the profit of the MEV rETH arbitrage opportunity that launching your minipool creates.
+
+To learn more about rocketarb, feel free to inquire about it on the [RP discord server](https://discord.gg/rocketpool).
 :::
 
 ::: tip NOTE
@@ -230,8 +232,6 @@ If you **understand these risks** and **believe this is the case**, the CLI will
 :::
 
 You will next be prompted with the network's current gas costs recommendations; confirm your gas price selection and follow the rest of the prompts. 
-
-*If you want to take advantage of [rocketarb](https://github.com/xrchz/rocketarb/blob/main/README.md) to capture the profit of the MEV rETH arbitrage opportunity that launching your minipool creates - this is the step where you will do it. Instructions can be found on the rocketarb README*
 
 ```
 Your eth2 client is on the correct network.

--- a/src/guides/node/create-validator.md
+++ b/src/guides/node/create-validator.md
@@ -219,7 +219,9 @@ In this case, you may want to do the deposit anyway to save time and begin valid
 If you **understand these risks** and **believe this is the case**, the CLI will let you go ahead with a deposit anyway.
 :::
 
-You will next be prompted with the network's current gas costs recommendations; confirm your gas price selection and follow the rest of the prompts:
+You will next be prompted with the network's current gas costs recommendations; confirm your gas price selection and follow the rest of the prompts. 
+
+*If you want to take advantage of [rocketarb](https://github.com/xrchz/rocketarb/blob/main/README.md) to capture the profit of the MEV rETH arbitrage opportunity that launching your minipool creates - this is the step where you will do it. Instructions can be found on the rocketarb README*
 
 ```
 Your eth2 client is on the correct network.


### PR DESCRIPTION
Creates a note at the appropriate step to tell people launching minipools that rocketarb exists and they can optionally use it at this point to capture the arbitrage opportunity