### PR TITLE
Remove mention of deprecated term ETH2

### DIFF
--- a/src/developers/README.md
+++ b/src/developers/README.md
@@ -1,6 +1,6 @@
 # Developer Documentation
 
-Rocket Pool is a first of its kind ETH2 Proof of Stake Protocol, designed to be community owned, decentralised, trustless and compatible with staking in Ethereum 2.0.
+Rocket Pool is a first of its kind ETH Proof of Stake Protocol, designed to be community owned, decentralised, trustless and compatible with staking in Ethereum.
 
 If you wish to secure your node, understand the smart node CLI better, figure out how to build on top of our smart contracts or even use our javascript library to build your own frontend for the protocol as a whitelabel staking solution, then you're at the right place.
 

--- a/src/index.md
+++ b/src/index.md
@@ -1,7 +1,7 @@
 ---
 home: false
 heroImage: /images/logo.png
-tagline: Decentralised & Trustless ETH2 Staking Protocol
+tagline: Decentralised & Trustless ETH Staking Protocol
 actionText: Get Started →
 actionLink: /overview/
 features:

--- a/src/overview/README.md
+++ b/src/overview/README.md
@@ -1,15 +1,15 @@
 # :wave: Introduction
 
-Rocket Pool is a first of its kind ETH2 Proof of Stake Protocol, designed to be community owned, decentralised, trustless and compatible with staking in Ethereum 2.0. It was first conceived in late 2016 and has since had over 5 successful public betas over the life span of ETH2 development.
+Rocket Pool is a first of its kind ETH Proof of Stake Protocol, designed to be community owned, decentralised, trustless and compatible with staking in Ethereum. It was first conceived in late 2016 and has since had over 5 successful public betas over the life span of ETH development.
 
 Rocket Pool is designed to cater to two main user groups; those that wish to participate in [tokenised staking using rETH](https://medium.com/rocket-pool/rocket-pool-2-5-tokenised-staking-48601d52d924#92b0) using as little as **0.01 ETH** and those that wish to stake ETH and run a node in the network to help generate a higher ROI than staking outside of the protocol due to commissions earned. 
 
 For more information on these two groups that make up the protocol, we'd highly recommend [reading article one in our explainer series](https://medium.com/rocket-pool/rocket-pool-staking-protocol-part-1-8be4859e5fbd) that goes into great detail on how users can participate, be it via tokenised staking or running a node in the protocol.
 
-The core premise behind a protocol is to ensure the network is not beholden to any one party. This is a principle directly linked to Ethereum and ETH2 itself, and a mindset used at every stage of the process as Rocket Pool has evolved.
+The core premise behind a protocol is to ensure the network is not beholden to any one party. This is a principle directly linked to Ethereum and ETH itself, and a mindset used at every stage of the process as Rocket Pool has evolved.
 
 [![A 10,000 foot view of the components which make up the Rocket Pool Staking Protocol](/images/rp-infographic-staking-protocol.png)](https://www.rocketpool.net/images/rp-infographic-staking-protocol.png)
 
 Rocket Pool strives to embody the core ethos of Ethereum and DeFi, specifically the non-custodial, trustless nature that allows self-sovereignty to truly thrive.
 
-This is why creating this base protocol layer for ETH2 staking is so important, especially with the vast majority of players either not having the technical skills to run a node, or the financial capacity to own 32 ETH.
+This is why creating this base protocol layer for ETH staking is so important, especially with the vast majority of players either not having the technical skills to run a node, or the financial capacity to own 32 ETH.


### PR DESCRIPTION
Within the Ethereum community, it is a broad consensus that the term "ETH2" is misleading to newer members and has thus been deprecated.
Further arguments on why this change is crucial can be found here: https://ethereum.org/en/upgrades/#eth2
As an important part of Ethereum infrastructure, Rocket Pool should follow this common agreement and only use "ETH" instead.
