### PR TITLE
Remove duplicated section

### DIFF
--- a/src/guides/node/withdraw.md
+++ b/src/guides/node/withdraw.md
@@ -72,7 +72,7 @@ At this point, you can access it using the Smartnode CLI to do a distribution.
 
 ::: tip NOTE
 This process requires your validator to be exited from the Beacon Chain and your validator's balance to have been transferred to the minipool contract.
-If you need a refresher on how to do that process, please see the [**Exiting your Validator**](#exiting-your-validator) section below - return here once you're done.
+If you need a refresher on how to do that process, please see the [**Exiting your Validator**](#exiting-your-validator) section above - return here once you're done.
 :::
 
 If you have exited your validator from the Beacon Chain and your balance has been deposited into the minipool contract, you can safely withdraw the entire thing in one command.
@@ -124,38 +124,3 @@ If you are an advanced user and bypass the CLI to invoke the distribution functi
 
 Because of these points, we **strongly recommend** you just upgrade to the Atlas delegate in the first place and avoid them entirely.
 :::
-
-::: tip NOTE
-This process requires your validator to be exited from the Beacon Chain and your validator's balance to have been transferred to the minipool contract.
-If you need a refresher on how to do that process, please see the [**Exiting your Validator**](#exiting-your-validator) section below - return here once you're done.
-:::
-
-If you have exited your validator from the Beacon Chain and your balance has been deposited into the minipool contract, you can safely withdraw the entire thing in one command.
-Unlike the `distribute` command above, this process will actually **finalize** your minipool which closes it and renders it inactive.
-For all intents and purposes, once your balance has been withdrawn from the Beacon Chain and you go through the following process to access the funds, the minipool's duty is over.
-
-To retrieve the funds and close the minipool, run the following command:
-
-```
-rocketpool minipool close
-```
-
-This will present you with a list of minipools that are eligible for closure:
-
-```
-Please select a minipool to close:
-1: All available minipools
-2: 0xffCAB546539b55756b1F85678f229dd707328A2F (32.074633 ETH available, 8.026494 ETH is yours plus a refund of 0.000000 ETH)
-```
-
-Here you can see the total balance for each eligible minipool, how much of that balance will be distributed to you, and how much of that balance is reserved for you as a refund (which bypasses distribution).
-
-Select which minipool you'd like to distribute and close from the list, confirm the action, and all you need to do is wait for your transaction to be validated.
-Once it does, your share of the minipool balance (and your refund) will be sent to your withdrawal address, and the minipool will enter the `finalized` state.
-
-You can verify it by looking at the transaction on a block explorer; for example, feel free to look at [the transaction for closing the above minipool](https://zhejiang.beaconcha.in/tx/0x5557d5e052422d4a46bb4204cabb8093b22fc944664aa0d5d4e8c9adca1865a5).
-
-At this point, your effective RPL will be updated to remove this minipool from the calculation.
-You can now unstake any RPL you have that would put you over the 150% limit. 
-
-


### PR DESCRIPTION
Removed duplicated section on distributing node rewards in the Shut Down a Minipool Guide.