### PR TITLE
Add a link to create a new minipool at the end of the leb-migration.md

### DIFF
--- a/src/guides/node/leb-migration.md
+++ b/src/guides/node/leb-migration.md
@@ -208,4 +208,4 @@ The node has 8.000000 ETH in its credit balance, which can be used to make new m
 ```
 
 The bond reduction process has **increased the node's** [deposit credit balance](./credit.md) by 8 ETH.
-This credit can be used to make another 8-ETH minipool for free (no ETH required from the node wallet, except for gas)!
+This credit can be used to [make another 8-ETH minipool](./create-validator.md#depositing-eth-and-creating-a-minipool) for free (no ETH required from the node wallet, except for gas)!


### PR DESCRIPTION
Hey folks :wave:

As someone that plans on migrating my pools post Atlas, I found that the `leb-migration.md` doesn't really provide next steps on how to go and create a minipool from the existing credit. I know this is going to be trivial for most users, but I thought a link at the very least couldn't harm.

I tried to use relative links like the others used on the page 🚀 🎱 

