### PR TITLE
emphasize restart instruction

### DIFF
--- a/src/guides/node/starting-rp.md
+++ b/src/guides/node/starting-rp.md
@@ -70,8 +70,8 @@ Stopping rocketpool_eth2       ... done
 Stopping rocketpool_eth1       ... done
 ```
 
-::: tip NOTE
-Once you call this, Rocket Pool will not automatically start after a system reboot.
+::: warning NOTE
+Once you call this, Rocket Pool will **not** automatically start after a system reboot.
 You will have to call `rocketpool service start` to start all of the Docker containers and enable auto-start on reboot again.
 
 :::


### PR DESCRIPTION
PR escalates an information box from `tip` to `warning`.

The green-box here can give false impression that everything is OK & no action is required.

Green == skippable