### PR TITLE
Update securing-your-node.md 2FA instructions

### DIFF
--- a/src/guides/node/securing-your-node.md
+++ b/src/guides/node/securing-your-node.md
@@ -438,6 +438,11 @@ Add the following line to the bottom of the file, which indicates to `sshd` that
 AuthenticationMethods publickey,keyboard-interactive:pam
 ```
 
+You will also need to set
+```shell
+PermitRootLogin yes
+```
+
 Then save and exit the file with `Ctrl+O`, `Enter`, and `Ctrl+X`.
 
 Now that `sshd` is set up, we need to create our 2FA codes.


### PR DESCRIPTION
I was not able to enable 2FA for a long time until I finally figured out that I need to set `PermitRootLogin` to `yes`