### PR TITLE
Update withdraw testnet examples

### DIFF
--- a/src/guides/node/withdraw.md
+++ b/src/guides/node/withdraw.md
@@ -7,6 +7,7 @@ When you have decided that you no longer want to run a minipool and want to acce
 1. Send a voluntarily exit request for the minipool's validator from the Beacon Chain.
 2. Wait for your validator to exit.
 3. Wait for your validator's balance to be withdrawn to your minipool on the Execution layer.
+4. Close the minipool to distrubute the rewards and access the funds
 
 We'll cover each step below.
 
@@ -69,8 +70,8 @@ If you need a refresher on how to do that process, please see the [**Exiting you
 :::
 
 If you have exited your validator from the Beacon Chain and your balance has been deposited into the minipool contract, you can safely withdraw the entire thing in one command.
-Unlike the `distribute` command, this process will actually **finalize** your minipool which closes it and renders it inactive.
-For all intents and purposes, once your balance has been withdrawn from the Beacon Chain and you go through the following process to access the funds, the minipool's duty is over.
+Unlike [manual distribution](skimming.md#manual-distribution), this process will actually **finalize** your minipool which closes it and renders it inactive.
+Once your balance has been withdrawn from the Beacon Chain and you go through the following process to access the funds, the minipool's duty is over.
 
 To retrieve the funds and close the minipool, run the following command:
 
@@ -88,10 +89,12 @@ Please select a minipool to close:
 
 Here you can see the total balance for each eligible minipool, how much of that balance will be distributed to you, and how much of that balance is reserved for you as a refund (which bypasses distribution).
 
-Select which minipool you'd like to distribute and close from the list, confirm the action, and all you need to do is wait for your transaction to be validated.
+Select which minipool you'd like to distribute and close from the list, confirm the action, and wait for your transaction to be validated.
 Once it does, your share of the minipool balance (and your refund) will be sent to your withdrawal address, and the minipool will enter the `finalized` state.
 
-You can verify it by looking at the transaction on a block explorer; for example, feel free to look at [the transaction for closing the above minipool (Prater Testnet)](https://zhejiang.beaconcha.in/tx/0x5557d5e052422d4a46bb4204cabb8093b22fc944664aa0d5d4e8c9adca1865a5 ).
+You can verify it by looking at the transaction on a block explorer; for example, feel free to look at [the transaction for closing the above minipool (Prater Testnet)](https://zhejiang.beaconcha.in/tx/0x5557d5e052422d4a46bb4204cabb8093b22fc944664aa0d5d4e8c9adca1865a5).
+
+### Unstaking RPL
 
 At this point, your effective RPL will be updated to remove this minipool from the calculation.
 You can now unstake any RPL you have that would put you over the 150% limit.

--- a/src/guides/node/withdraw.md
+++ b/src/guides/node/withdraw.md
@@ -25,21 +25,14 @@ You will be presented with a list of minipools that can be exited:
 Please select a minipool to exit:
 1: All available minipools
 2: 0x7E5700bcd65B1770bA68abB288D3f53814d376aC (staking since 2023-02-08, 06:33 +0000 UTC)
-3: 0x7E570195026dC29f4B2DfF08B56c3b5D0FF988Ef (staking since 2023-02-08, 06:33 +0000 UTC)
-4: 0x7e5702a2cE66B5B35E59B9Ac00eEAAa547881e40 (staking since 2023-02-08, 06:33 +0000 UTC)
-5: 0x7E5703fdA638CD86c316B9EbAF76927fF695ADC5 (staking since 2023-02-08, 06:33 +0000 UTC)
-6: 0x7E5704aD2a63eb90880426Dcd4a3811246dF3cB0 (staking since 2023-02-08, 06:34 +0000 UTC)
-7: 0x7E5705c149D11efc951fFc20349D7A96bc6b819C (staking since 2023-02-08, 06:34 +0000 UTC)
-8: 0x7E570625cE8F586c90ACa7fe8792EeAA79751778 (staking since 2023-02-08, 06:56 +0000 UTC)
-9: 0x7E5700c82E38434C6c72890bb82f5B5305f4328a (staking since 2023-02-13, 06:11 +0000 UTC)
-10: 0xffCAB546539b55756b1F85678f229dd707328A2F (staking since 2023-02-16, 11:19 +0000 UTC)
+3: 0xd8E804cFA64ADb386F52DB20717810130c90f674 (staking since 2023-02-08, 06:33 +0000 UTC)
 ```
 
 Once you confirm you want to exit, your node will send a voluntary exit request to the Beacon Chain.
 This is **not** a normal Execution layer transaction, so you do not need to pay gas for it.
 
 If you need the validator public key for the minipool you just exited, you can retrieve it using `rocketpool minipool status`.
-You can view your validator's exit status on a Beacon Chain explorer such as [https://zhejiang.beaconcha.in](https://zhejiang.beaconcha.in) (for the Zhejiang testnet).
+You can view your validator's exit status on a Beacon Chain explorer such as [https://beaconcha.in](https://beaconcha.in) (or [https://prater.beaconcha.in](https://prater.beaconcha.in) for the Prater Testnet).
 It will take some time for your status to be updated, but once it is you will see it in the "exiting" state:
 
 <center>
@@ -72,11 +65,11 @@ At this point, you can access it using the Smartnode CLI to do a distribution.
 
 ::: tip NOTE
 This process requires your validator to be exited from the Beacon Chain and your validator's balance to have been transferred to the minipool contract.
-If you need a refresher on how to do that process, please see the [**Exiting your Validator**](#exiting-your-validator) section below - return here once you're done.
+If you need a refresher on how to do that process, please see the [**Exiting your Validator**](#exiting-your-validator) section above - return here once you're done.
 :::
 
 If you have exited your validator from the Beacon Chain and your balance has been deposited into the minipool contract, you can safely withdraw the entire thing in one command.
-Unlike the `distribute` command above, this process will actually **finalize** your minipool which closes it and renders it inactive.
+Unlike the `distribute` command, this process will actually **finalize** your minipool which closes it and renders it inactive.
 For all intents and purposes, once your balance has been withdrawn from the Beacon Chain and you go through the following process to access the funds, the minipool's duty is over.
 
 To retrieve the funds and close the minipool, run the following command:
@@ -90,7 +83,7 @@ This will present you with a list of minipools that are eligible for closure:
 ```
 Please select a minipool to close:
 1: All available minipools
-2: 0xffCAB546539b55756b1F85678f229dd707328A2F (32.074633 ETH available, 8.026494 ETH is yours plus a refund of 0.000000 ETH)
+2: 0xd8E804cFA64ADb386F52DB20717810130c90f674 (32.074633 ETH available, 8.026494 ETH is yours plus a refund of 0.000000 ETH)
 ```
 
 Here you can see the total balance for each eligible minipool, how much of that balance will be distributed to you, and how much of that balance is reserved for you as a refund (which bypasses distribution).
@@ -98,10 +91,17 @@ Here you can see the total balance for each eligible minipool, how much of that 
 Select which minipool you'd like to distribute and close from the list, confirm the action, and all you need to do is wait for your transaction to be validated.
 Once it does, your share of the minipool balance (and your refund) will be sent to your withdrawal address, and the minipool will enter the `finalized` state.
 
-You can verify it by looking at the transaction on a block explorer; for example, feel free to look at [the transaction for closing the above minipool](https://zhejiang.beaconcha.in/tx/0x5557d5e052422d4a46bb4204cabb8093b22fc944664aa0d5d4e8c9adca1865a5).
+You can verify it by looking at the transaction on a block explorer; for example, feel free to look at [the transaction for closing the above minipool (Prater Testnet)](https://zhejiang.beaconcha.in/tx/0x5557d5e052422d4a46bb4204cabb8093b22fc944664aa0d5d4e8c9adca1865a5 ).
 
 At this point, your effective RPL will be updated to remove this minipool from the calculation.
 You can now unstake any RPL you have that would put you over the 150% limit.
+
+To unstake RPL against the node, run the following command: 
+
+```
+rocketpool node withdraw-rpl
+```
+
 
 ## A Note on the Old Delegate
 

--- a/src/guides/node/withdraw.md
+++ b/src/guides/node/withdraw.md
@@ -84,7 +84,7 @@ This will present you with a list of minipools that are eligible for closure:
 ```
 Please select a minipool to close:
 1: All available minipools
-2: 0xd8E804cFA64ADb386F52DB20717810130c90f674 (32.074633 ETH available, 8.026494 ETH is yours plus a refund of 0.000000 ETH)
+2: 0xd8E804cFA64ADb386F52DB20717810130c90f674 (32.007209 ETH available, 8.002559 ETH is yours plus a refund of 0.000000 ETH)
 ```
 
 Here you can see the total balance for each eligible minipool, how much of that balance will be distributed to you, and how much of that balance is reserved for you as a refund (which bypasses distribution).
@@ -92,7 +92,7 @@ Here you can see the total balance for each eligible minipool, how much of that 
 Select which minipool you'd like to distribute and close from the list, confirm the action, and wait for your transaction to be validated.
 Once it does, your share of the minipool balance (and your refund) will be sent to your withdrawal address, and the minipool will enter the `finalized` state.
 
-You can verify it by looking at the transaction on a block explorer; for example, feel free to look at [the transaction for closing the above minipool (Prater Testnet)](https://zhejiang.beaconcha.in/tx/0x5557d5e052422d4a46bb4204cabb8093b22fc944664aa0d5d4e8c9adca1865a5).
+You can verify it by looking at the transaction on a block explorer; for example, see [the transaction for closing the above minipool (Goerli Testnet)](https://goerli.etherscan.io/tx/0xe81415b3b66f9b42d43ac17a0983e792725726c9fdd35ac855745bd12a053509).
 
 ### Unstaking RPL
 


### PR DESCRIPTION
Replaced dead links from the old zhejiang testnet to goerli/prater and updated example withdraw process.
Added note on how to unstake RPL.